### PR TITLE
Adding dedicated structures for web and api response

### DIFF
--- a/cmd/upcheck/main.go
+++ b/cmd/upcheck/main.go
@@ -1,7 +1,0 @@
-package main
-
-import "github.com/atharv3221/uptimecheck/internal/uptimecheck"
-
-func main() {
-	uptimecheck.UptimeCheck("https://github.com")
-}

--- a/cmd/uptimecheck/main.go
+++ b/cmd/uptimecheck/main.go
@@ -1,0 +1,7 @@
+package main
+
+import "github.com/atharv3221/uptimecheck/internal/client"
+
+func main() {
+	client.UptimeCheck("https://github.com")
+}

--- a/internal/client/uptime.go
+++ b/internal/client/uptime.go
@@ -1,4 +1,4 @@
-package uptimecheck
+package client
 
 import (
 	"log/slog"

--- a/internal/structure/apiResponse.go
+++ b/internal/structure/apiResponse.go
@@ -1,0 +1,46 @@
+package structure
+
+import "time"
+
+// HTTPMethod represents HTTP verbs.
+type HTTPMethod string
+
+const (
+	GET    HTTPMethod = "GET"
+	POST   HTTPMethod = "POST"
+	PUT    HTTPMethod = "PUT"
+	DELETE HTTPMethod = "DELETE"
+)
+
+// APIStatus represents success or failure of the API response.
+type APIStatus string
+
+const (
+	Failed     APIStatus = "failed"
+	Successful APIStatus = "successful"
+)
+
+// APIResponse is the main struct representing an API test/check result.
+type APIResponse struct {
+	URL            string            `json:"url"`
+	Method         HTTPMethod        `json:"method"`
+	Status         APIStatus         `json:"status"`
+	HTTPStatus     int               `json:"http_status"`
+	ResponseTimeMs int               `json:"response_time_ms"`
+	Headers        map[string]string `json:"headers"`
+	Body           string            `json:"body"`
+	CheckedAt      time.Time         `json:"checked_at"`
+}
+
+// Methods to satisfy some interface (if needed).
+func (a APIResponse) GetStatus() int {
+	return a.HTTPStatus
+}
+
+func (a APIResponse) GetURL() string {
+	return a.URL
+}
+
+func (a APIResponse) GetBody() string {
+	return a.Body
+}

--- a/internal/structure/websiteResponse.go
+++ b/internal/structure/websiteResponse.go
@@ -1,0 +1,29 @@
+package structure
+
+import "time"
+
+// WebsiteStatus represents whether the site is up or down.
+type WebsiteStatus string
+
+const (
+	Up   WebsiteStatus = "up"
+	Down WebsiteStatus = "down"
+)
+
+// WebsiteResponse represents the result of a website uptime check.
+type WebsiteResponse struct {
+	URL            string        `json:"url"`
+	Status         WebsiteStatus `json:"status"`
+	HTTPStatus     int           `json:"http_status"`
+	ResponseTimeMs int           `json:"response_time_ms"`
+	CheckedAt      time.Time     `json:"checked_at"`
+}
+
+// Methods for interface and usage convenience
+func (w WebsiteResponse) GetStatus() int {
+	return w.HTTPStatus
+}
+
+func (w WebsiteResponse) GetURL() string {
+	return w.URL
+}


### PR DESCRIPTION
New structure Website Response 
```
type WebsiteResponse struct {
	URL            string        `json:"url"`
	Status         WebsiteStatus `json:"status"`
	HTTPStatus     int           `json:"http_status"`
	ResponseTimeMs int           `json:"response_time_ms"`
	CheckedAt      time.Time     `json:"checked_at"`
}
```
New structure API Response 
```
type APIResponse struct {
	URL            string            `json:"url"`
	Method         HTTPMethod        `json:"method"`
	Status         APIStatus         `json:"status"`
	HTTPStatus     int               `json:"http_status"`
	ResponseTimeMs int               `json:"response_time_ms"`
	Headers        map[string]string `json:"headers"`
	Body           string            `json:"body"`
	CheckedAt      time.Time         `json:"checked_at"`
}
```
